### PR TITLE
add flag to skip umask

### DIFF
--- a/providers/server.rb
+++ b/providers/server.rb
@@ -92,7 +92,9 @@ action :start do
     variables(
       "serverName" => new_resource.server_name,
       "cleanStart" => new_resource.clean, 
-      "installDir" => installDir
+      "installDir" => installDir,
+      "skipUmask"  => new_resource.skip_umask
+
     )
 
     notifies :restart, "service[wlp-#{new_resource.server_name}]", :delayed

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -86,5 +86,8 @@ attribute :bootstrapProperties, :kind_of => Hash, :default => {}
 #<> @attribute clean Clean all cached information when starting the server instance.
 attribute :clean, :kind_of => [TrueClass, FalseClass], :default => false
 
+#<> @attribute skip_umask Skip setting umask and use user default.
+attribute :skip_umask, :kind_of => [TrueClass, FalseClass], :default => false
+
 default_action :start
 

--- a/templates/default/init.d.erb
+++ b/templates/default/init.d.erb
@@ -20,6 +20,7 @@ export WLP_INSTALL_DIR="<%= @installDir %>"
 <%= "export WLP_USER_DIR=\"#{@userDir}\"" if @userDir %>
 
 SERVER_NAME="<%= @serverName %>"
+export WLP_SKIP_UMASK=<%= @skipUmask ? "true" : "" %>
 
 start_service() {
   OPTIONS=<%= @cleanStart ? "--clean" : "" %>


### PR DESCRIPTION
For webapps that write files on disk, in our case a sitemap index, that needs to be read by the apache, we need to set the skip umask flag to create files with correct permissions.