### PR TITLE
Resolve Chef 13 migration error.

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -43,8 +43,9 @@ end
 =end
 actions :create, :create_if_missing
 
+# attribute :file, :kind_of => String, :name_attribute => true
 #<> @attribute file The server.xml file to create or update.
-attribute :file, :kind_of => String, :default => nil, :name_attribute => true
+attribute :file, :kind_of => String, :name_attribute => true
 
 #<> @attribute config The contents of the server.xml file expressed as a hash.
 attribute :config, :kind_of => [Hash], :default => nil


### PR DESCRIPTION
This is a request to resolve a Chef 13 migration error.

Cannot specify both default and name_property together on property file of resource wlp_config. Only one (name_property) will be obeyed. In Chef 13, this will become an error. Please remove one or the other from the property. at 1 location:
           - /tmp/kitchen/cache/cookbooks/wlp/resources/config.rb:47:in `class_from_file'

This has already been reported previously as Issue #46.  

Thank You. 


