### PR TITLE
Fixes validations in Chef 13 for LWRP attributes

### DIFF
--- a/providers/download_feature.rb
+++ b/providers/download_feature.rb
@@ -49,12 +49,6 @@ action :download do
     action :create
   end
 
-  if new_resource.directory == nil
-    directory = node[:wlp][:base_dir]
-  else
-    directory = new_resource.directory
-  end
-
   if new_resource.name =~ /:\/\//
     name_uri = ::URI.parse(new_resource.name)
     name_filename = ::File.basename(name_uri.path)
@@ -68,7 +62,7 @@ action :download do
     name = new_resource.name
   end
   command = "#{@utils.installDirectory}/bin/installUtility download"
-  command << " --location=#{directory}"
+  command << " --location=#{new_resource.directory}"
   if new_resource.accept_license
     command << " --acceptLicense"
   end

--- a/resources/download_feature.rb
+++ b/resources/download_feature.rb
@@ -36,10 +36,10 @@ actions :download
 
 
 #<> @attribute name Specifies the name of the asset to be downloaded.
-attribute :name, :kind_of => String, :default => nil
+attribute :name, :kind_of => String
 
 #<> @attribute directory Specifies which local directory path utilities are downloaded to when using the :download action.
-attribute :directory, :kind_of => String, :default => nil
+attribute :directory, :kind_of => String, :default => lazy { node[:wlp][:base_dir] }
 
 #<> @attribute accept_license Specifies whether to accept the license terms and conditions of the feature.
 attribute :accept_license, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/install_feature.rb
+++ b/resources/install_feature.rb
@@ -35,7 +35,7 @@ actions :install
 
 
 #<> @attribute name Specifies the name of the asset to be installed.
-attribute :name, :kind_of => String, :default => nil
+attribute :name, :kind_of => String
 
 #<> @attribute to Specifies where to install the feature. The feature can be installed to any configured product extension location, or as a user feature.
 attribute :to, :kind_of => String, :default => "usr"


### PR DESCRIPTION
The `:kind_of` types set for several LWRPs are Strings but their default
values are `nil`. In Chef13, there is apparently a strict validation
enforcing the types of the assigned values or default values of an
attribute match their type. The affected resources and attributes are:

* `install_feature` resource - `name` property
* `download_feature` resource - `name` and `directory` properties

The default values for `name` properties have been removed since names
are required for resources anyway, they should never be `nil`. The
`directory` property is now defaulted to the `node[:wlp][:base_dir]`
since that is what has happening behind the scenes in the provider
anyway.

Fixes #51